### PR TITLE
Add until fail decorator

### DIFF
--- a/src/decorators/until-fail-decorator.ts
+++ b/src/decorators/until-fail-decorator.ts
@@ -1,0 +1,10 @@
+import Decorator from '@/decorators/decorator'
+import {NodeState} from '@/enums'
+
+export class UntilFailDecorator<T> extends Decorator<T> {
+  public tick(blackBoard: T): NodeState {
+    const state = super.tick(blackBoard)
+
+    return state === NodeState.Failed ? NodeState.Succeeded : NodeState.Running
+  }
+}

--- a/tests/decorators/until-fail-decorator.spec.ts
+++ b/tests/decorators/until-fail-decorator.spec.ts
@@ -1,0 +1,22 @@
+import {UntilFailDecorator} from '@/decorators/until-fail-decorator'
+import {ActionLeaf} from '@/leafs'
+import {NodeState} from '@/enums'
+import {testBlackboard} from '@test/test-blackboard'
+import each from 'jest-each'
+
+describe('UntilFailDecorator', () => {
+  it('should return succeeded state when child returns failed state', () => {
+    const node = new UntilFailDecorator(new ActionLeaf(() => NodeState.Failed))
+
+    expect(node.tick(testBlackboard)).toBe(NodeState.Succeeded)
+  })
+
+  each([NodeState.Succeeded, NodeState.Running]).it(
+    'should return running state for %s state',
+    (state) => {
+      const node = new UntilFailDecorator(new ActionLeaf(() => state))
+
+      expect(node.tick(testBlackboard)).toBe(NodeState.Running)
+    }
+  )
+})


### PR DESCRIPTION
> These decorators will continue to reprocess their child. That is until the child finally returns a failure, at which point the repeater will return success to its parent.

See for extra details:

- https://github.com/libgdx/gdx-ai/wiki/Behavior-Trees#decorator
- https://www.gamasutra.com/blogs/ChrisSimpson/20140717/221339/Behavior_trees_for_AI_How_they_work.php