### PR TITLE
fix(decorator): fix logic for succeeder decorator

### DIFF
--- a/src/decorators/succeeder-decorator.ts
+++ b/src/decorators/succeeder-decorator.ts
@@ -3,8 +3,8 @@ import {NodeState} from '@/enums/node-state.enum'
 
 export class SucceederDecorator<T> extends Decorator<T> {
   public tick(blackBoard: T): NodeState {
-    super.tick(blackBoard)
+    const state = super.tick(blackBoard)
 
-    return NodeState.Succeeded
+    return state === NodeState.Running ? NodeState.Running : NodeState.Succeeded
   }
 }

--- a/tests/decorators/succeeder-decorator.spec.ts
+++ b/tests/decorators/succeeder-decorator.spec.ts
@@ -5,7 +5,13 @@ import {NodeState} from '@/enums'
 import {testBlackboard} from '@test/test-blackboard'
 
 describe('SucceederDecorator', () => {
-  each([NodeState.Succeeded, NodeState.Failed, NodeState.Running]).it(
+  it('should return running state when child returns running state', () => {
+    const node = new SucceederDecorator(new ActionLeaf(() => NodeState.Running))
+
+    expect(node.tick(testBlackboard)).toBe(NodeState.Running)
+  })
+
+  each([NodeState.Succeeded, NodeState.Failed]).it(
     'should return succeeded state when child returns %s state',
     (state) => {
       const node = new SucceederDecorator(new ActionLeaf(() => state))


### PR DESCRIPTION
Succeeder decorators should return running when its child returns a running state.